### PR TITLE
(maint) Add copyright notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,9 @@ Structured logging is a slippery slope and should be applied where it has
 clear benefits. While we've streamlined it a lot, this is heavier than regular
 logging, and it's still non-application code that you have to scatter throughout
 your program.
+
+## License
+
+Copyright © 2015 Puppet Labs
+
+Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.html)


### PR DESCRIPTION
This adds a simple copyright notice with attribution to the project, where none exist currently. It is copied from the one present in puppetlabs/trapperkeeper.

As part of the effort to package this project for Debian, I noticed this was missing. Correct copyright attribution is a requirement for software entering the Debian archive, otherwise it may get rejected.